### PR TITLE
Check for para leases

### DIFF
--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -1,0 +1,38 @@
+use subxt::{OnlineClient, PolkadotConfig};
+
+use crate::query::maybe_leases;
+
+pub enum Chain {
+    DOT,
+    KSM,
+    ROC,
+}
+
+pub type Api = OnlineClient::<PolkadotConfig>;
+
+// Returns if the passed para_id is applicable for a permanent slot in Rococo
+pub async fn needs_perm_slot(
+    para_id: u32
+) -> Result<bool, Box<dyn std::error::Error>> {
+    
+    let polkadot_api = OnlineClient::<PolkadotConfig>::from_url("wss://rpc.polkadot.io:443").await?;
+    let kusama_api = OnlineClient::<PolkadotConfig>::from_url("wss://kusama-rpc.polkadot.io:443").await?;
+    let _rococo_api = OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
+
+    let lease_polkadot = maybe_leases(
+        polkadot_api,
+        Chain::DOT,
+        para_id
+    ).await;
+
+    let lease_kusama = maybe_leases(
+        kusama_api,
+        Chain::KSM,
+        para_id
+    ).await;
+
+    if lease_kusama.unwrap() || lease_polkadot.unwrap() {
+        println!("ParaId: {} needs a permanent slot", para_id);
+        Ok(true)
+    } else { Ok(false) }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod helper;
+pub mod query;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,6 @@
 
 use clap::Parser;
-
-mod api;
-use api::query::{exists_in_polkadot, exists_in_kusama};
-
+use para_onboarding::helper::needs_perm_slot;
 
 #[derive(Parser, Debug)]
 #[command(about = "CLI tool to onboard parachains.")]
@@ -20,24 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Parachain ID: {}", args.para_id);
     println!("Manager Address: {}", args.account_address);
 
-    let is_in_polkadot = exists_in_polkadot(args.para_id).await;
-    let is_in_kusama = exists_in_kusama(args.para_id).await;
-    let is_exists = match is_in_polkadot {
-        Ok(is_exists) => 
-            match is_in_kusama {
-                Ok(is_exists_kusama) => is_exists || is_exists_kusama,
-                Err(v) => Err(format!("Error querying the chain: {}", v))?
-            },
-        Err(v) => Err(format!("Error querying the chain: {}", v))?
-    };
-    if is_exists {
-        // Chain exists on Polkadot/Kusama -> long term
-        println!("Parachain exists");
-    }
-    else {
-        // Chain does not exist on Polkadot/Kusama -> short term
-        println!("This parachain does not exist");
-    }
+    let _perm_slot: bool = needs_perm_slot(args.para_id).await.unwrap_or(false);
     
     Ok(())
 }

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -1,0 +1,41 @@
+use crate::helper::{Chain, Api};
+
+#[subxt::subxt(runtime_metadata_path = "metadata/polkadot_metadata.scale")]
+pub mod polkadot {}
+
+#[subxt::subxt(runtime_metadata_path = "metadata/kusama_metadata.scale")]
+pub mod kusama {}
+
+#[subxt::subxt(runtime_metadata_path = "metadata/rococo_metadata.scale")]
+pub mod rococo {}
+
+use polkadot::runtime_types::polkadot_parachain::primitives::Id;
+use kusama::runtime_types::polkadot_parachain::primitives::Id as KusamaId;
+use rococo::runtime_types::polkadot_parachain::primitives::Id as RococoId;
+
+
+// Checks if paraId holds any leases on the specified chain
+//
+pub async fn maybe_leases(
+    api: Api,
+    chain: Chain,
+    para_id: u32
+) -> Result<bool, Box<dyn std::error::Error>> {
+    
+    let query = match chain {
+        Chain::DOT => polkadot::storage().slots().leases(Id(para_id)),
+        Chain::KSM => kusama::storage().slots().leases(KusamaId(para_id)),
+        Chain::ROC => rococo::storage().slots().leases(RococoId(para_id)),
+    };
+    
+    match api
+        .storage()
+        .at_latest()
+        .await?
+        .fetch(&query)
+        .await?
+    {
+        Some(_) => Ok(true),
+        _ => Ok(false),
+    }
+}


### PR DESCRIPTION
This MR substitutes the logic checking if a certain para exists with a query to the slots that para is holding, if any. In case that pars is holding a lease then it is eligible for a permanent slot, otherwise it will be assigned a temporary one.

Most likely returns and error handling will need to be revisited. I would like for `maybe_leases` to return `Option<bool>`, now it returns `Result<bool, Box<dyn std::error::Error>>`.