### PR TITLE
Check and register parachain in Rococo

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1694,6 +1694,7 @@ dependencies = [
  "clap",
  "dotenv",
  "parity-scale-codec",
+ "sp-keyring",
  "subxt",
  "tokio",
 ]
@@ -2646,6 +2647,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-keyring"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f0fc76f89011d39243e87650e3bf747ee4b19abaaeb2702988a2e0b0a7d77c"
+dependencies = [
+ "lazy_static",
+ "sp-core",
+ "sp-runtime",
+ "strum",
+]
+
+[[package]]
 name = "sp-keystore"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,6 +2887,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "substrate-bip39"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { version = "1.12.0", features = ["full"] } # for our async runtime
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 subxt = "0.28.0" 
 dotenv = "0.15.0" # for secret variables
+sp-keyring = "23.0.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,12 +20,14 @@ Arguments:
   <ACCOUNT_ADDRESS>  Manager Address
 
 Options:
-  -h, --help  Print help
+  -g, --path-genesis-head <PATH_GENESIS_HEAD>        Path to a file with a genesis head
+  -v, --path-validation-code <PATH_VALIDATION_CODE>  Path to the wasm file
+  -h, --help                                         Print help
 ```
 
 Run locally:
 ```shell
-cargo run para_id account_address
+cargo run para_id account_address -g genesis_head -v validation_code
 ```
 The metadata used for subxt has been queried with:
 ```shell

--- a/cli/src/calls.rs
+++ b/cli/src/calls.rs
@@ -1,0 +1,44 @@
+use crate::helper::Api;
+use sp_keyring::AccountKeyring;
+use subxt::{tx::PairSigner, utils::AccountId32};
+
+#[subxt::subxt(runtime_metadata_path = "metadata/rococo_metadata.scale")]
+pub mod rococo {}
+
+use rococo::runtime_types::polkadot_parachain::primitives::Id as RococoId;
+use rococo::runtime_types::polkadot_parachain::primitives::{HeadData, ValidationCode};
+
+type Call = rococo::runtime_types::rococo_runtime::RuntimeCall;
+type RegistrarCall = rococo::runtime_types::polkadot_runtime_common::paras_registrar::pallet::Call;
+
+//
+// Register the parachain with sudo
+//
+pub async fn force_register(
+    api: Api,
+    para_id: u32,
+    account_manager: AccountId32,
+    genesis_head: String,
+    validation_code: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let alice = PairSigner::new(AccountKeyring::Alice.pair());
+
+    let call = Call::Registrar(RegistrarCall::force_register {
+        who: account_manager,
+        deposit: 10_000,
+        id: RococoId(para_id),
+        genesis_head: HeadData(genesis_head.into()),
+        validation_code: ValidationCode(validation_code.into()),
+    });
+
+    let tx = rococo::tx().sudo().sudo(call);
+
+    api.tx()
+        .sign_and_submit_then_watch_default(&tx, &alice)
+        .await?
+        .wait_for_finalized_success()
+        .await?
+        .has::<rococo::sudo::events::Sudid>()?;
+
+    Ok(())
+}

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -2,7 +2,7 @@ use std::{fs, path::PathBuf};
 use subxt::{utils::AccountId32, OnlineClient, PolkadotConfig};
 
 use crate::calls::force_register;
-use crate::query::maybe_leases;
+use crate::query::{maybe_leases, paras_registered};
 
 pub enum Chain {
     DOT,
@@ -34,10 +34,23 @@ pub async fn needs_perm_slot(para_id: u32) -> Result<bool, Box<dyn std::error::E
 pub async fn has_slot_in_rococo(para_id: u32) -> Result<bool, Box<dyn std::error::Error>> {
     // let rococo_api =
     //     OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
-    let rococo_api = OnlineClient::<PolkadotConfig>::from_url("wss://127.0.0.1:56759").await?;
+    let rococo_api = OnlineClient::<PolkadotConfig>::from_url("ws://127.0.0.1:9944").await?;
     let lease_rococo = maybe_leases(rococo_api, Chain::ROC, para_id).await;
 
     if lease_rococo.unwrap() {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+// Check if the parachain is registerd  in Rococo
+pub async fn is_registered(para_id: u32) -> Result<bool, Box<dyn std::error::Error>> {
+    // let rococo_api =
+    //     OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
+    let rococo_api = OnlineClient::<PolkadotConfig>::from_url("ws://127.0.0.1:9944").await?;
+    let is_registered_in_rococo = paras_registered(rococo_api, para_id).await;
+    if is_registered_in_rococo.unwrap() {
         Ok(true)
     } else {
         Ok(false)
@@ -60,13 +73,12 @@ pub async fn register(
 
     //let rococo_api = OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
     let rococo_api = OnlineClient::<PolkadotConfig>::from_url("ws://127.0.0.1:9944").await?;
-    let lease_rococo = force_register(
+    force_register(
         rococo_api,
         para_id,
         account_manager,
         genesis_head,
         validation_code,
     )
-    .await;
-    Ok(())
+    .await
 }

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -1,5 +1,7 @@
-use subxt::{OnlineClient, PolkadotConfig};
+use std::{fs, path::PathBuf};
+use subxt::{utils::AccountId32, OnlineClient, PolkadotConfig};
 
+use crate::calls::force_register;
 use crate::query::maybe_leases;
 
 pub enum Chain {
@@ -30,9 +32,9 @@ pub async fn needs_perm_slot(para_id: u32) -> Result<bool, Box<dyn std::error::E
 
 // Returns if the passed para_id already has a slot in Rococo
 pub async fn has_slot_in_rococo(para_id: u32) -> Result<bool, Box<dyn std::error::Error>> {
-    let rococo_api =
-        OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
-
+    // let rococo_api =
+    //     OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
+    let rococo_api = OnlineClient::<PolkadotConfig>::from_url("wss://127.0.0.1:56759").await?;
     let lease_rococo = maybe_leases(rococo_api, Chain::ROC, para_id).await;
 
     if lease_rococo.unwrap() {
@@ -40,4 +42,31 @@ pub async fn has_slot_in_rococo(para_id: u32) -> Result<bool, Box<dyn std::error
     } else {
         Ok(false)
     }
+}
+
+// Force the Register parachain
+pub async fn register(
+    para_id: u32,
+    account_manager: AccountId32,
+    path_genesis_head: PathBuf,
+    path_validation_code: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let validation_code = fs::read_to_string(path_validation_code)
+        .expect("Should have been able to read the validation code file");
+    let genesis_head = fs::read_to_string(path_genesis_head)
+        .expect("Should have been able to read the genesis file");
+
+    //let account_id32 = AccountId32::from(account_manager.into());
+
+    //let rococo_api = OnlineClient::<PolkadotConfig>::from_url("wss://rococo-rpc.polkadot.io:443").await?;
+    let rococo_api = OnlineClient::<PolkadotConfig>::from_url("ws://127.0.0.1:9944").await?;
+    let lease_rococo = force_register(
+        rococo_api,
+        para_id,
+        account_manager,
+        genesis_head,
+        validation_code,
+    )
+    .await;
+    Ok(())
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod calls;
 pub mod helper;
 pub mod query;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
-use para_onboarding::helper::{has_slot_in_rococo, needs_perm_slot};
+use para_onboarding::helper::{has_slot_in_rococo, needs_perm_slot, register};
+use std::{fs, path::PathBuf};
+use subxt::{tx::PairSigner, utils::AccountId32};
 
 #[derive(Parser, Debug)]
 #[command(about = "CLI tool to onboard parachains.")]
@@ -7,7 +9,13 @@ struct Cli {
     /// Parachain ID
     para_id: u32,
     /// Manager Address
-    account_address: String,
+    account_address: AccountId32,
+    /// Path to a file with a genesis head.
+    #[clap(long, short('g'), value_parser)]
+    path_genesis_head: PathBuf,
+    /// Path to the wasm file.
+    #[clap(long, short('v'), value_parser)]
+    path_validation_code: PathBuf,
 }
 
 #[tokio::main]
@@ -22,6 +30,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         return Ok(());
     }
+
+    register(
+        args.para_id,
+        args.account_address,
+        args.path_validation_code,
+        args.path_genesis_head,
+    )
+    .await?;
 
     let perm_slot: bool = needs_perm_slot(args.para_id).await.unwrap_or(false);
 

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -32,3 +32,17 @@ pub async fn maybe_leases(
         _ => Ok(false),
     }
 }
+
+//
+// Checks if paraId is already registered
+//
+pub async fn paras_registered(
+    api: Api,
+    para_id: u32,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let query = rococo::storage().paras().para_lifecycles(RococoId(para_id));
+    match api.storage().at_latest().await?.fetch(&query).await? {
+        Some(_) => Ok(true),
+        _ => Ok(false), 
+    }
+}

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -13,6 +13,7 @@ use kusama::runtime_types::polkadot_parachain::primitives::Id as KusamaId;
 use polkadot::runtime_types::polkadot_parachain::primitives::Id;
 use rococo::runtime_types::polkadot_parachain::primitives::Id as RococoId;
 
+//
 // Checks if paraId holds any leases on the specified chain
 //
 pub async fn maybe_leases(


### PR DESCRIPTION
Add genesis-head and validation-code in the CLI to register the parachain if it is not registered in Rococo yet.

From now to test it is querying a Local Rococo instance: `ws://127.0.0.1:9944` and the sudo account is Alice. Will have to change this.